### PR TITLE
Add smooth scroll animations to landing page sections

### DIFF
--- a/client/components/layout/MainLayout.tsx
+++ b/client/components/layout/MainLayout.tsx
@@ -8,8 +8,8 @@ import { useEffect } from "react";
 export const scrollToSection = (sectionId: string, push: boolean = true) => {
   const element = document.getElementById(sectionId);
   if (element) {
-    element.scrollIntoView({ behavior: 'smooth' });
-    if (push) window.history.pushState({}, '', `/${sectionId}`);
+    element.scrollIntoView({ behavior: "smooth" });
+    if (push) window.history.pushState({}, "", `/${sectionId}`);
   }
 };
 
@@ -20,7 +20,11 @@ export function Header() {
     <header className="sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-white/70 bg-white/90 border-b border-slate-200">
       <div className="px-6 sm:px-8 lg:px-12 xl:px-16 2xl:px-20 py-3 flex items-center justify-between w-full">
         <a href="/" className="flex items-center gap-2">
-          <img src="/logo-scriptlyfy.png" alt="Scriptlyfy" className="h-8 w-8 object-contain bg-transparent" />
+          <img
+            src="/logo-scriptlyfy.png"
+            alt="Scriptlyfy"
+            className="h-8 w-8 object-contain bg-transparent"
+          />
           <span className="text-base sm:text-lg font-semibold tracking-tight text-slate-900">
             Scriptlyfy
           </span>
@@ -31,7 +35,7 @@ export function Header() {
             className={navLink}
             onClick={(e) => {
               e.preventDefault();
-              scrollToSection('features');
+              scrollToSection("features");
             }}
           >
             Features
@@ -41,7 +45,7 @@ export function Header() {
             className={navLink}
             onClick={(e) => {
               e.preventDefault();
-              scrollToSection('demo');
+              scrollToSection("demo");
             }}
           >
             Demo
@@ -51,7 +55,7 @@ export function Header() {
             className={navLink}
             onClick={(e) => {
               e.preventDefault();
-              scrollToSection('pricing');
+              scrollToSection("pricing");
             }}
           >
             Pricing
@@ -61,15 +65,15 @@ export function Header() {
             className={navLink}
             onClick={(e) => {
               e.preventDefault();
-              scrollToSection('faq');
+              scrollToSection("faq");
             }}
           >
             FAQs
           </a>
         </nav>
         <div className="hidden md:flex items-center gap-3">
-          <Button 
-            onClick={() => scrollToSection('signup')}
+          <Button
+            onClick={() => scrollToSection("signup")}
             className="bg-[hsl(var(--brand))] hover:bg-[hsl(var(--brand))]/90"
           >
             Join Early Access
@@ -89,7 +93,11 @@ export function Footer() {
       <div className="px-6 sm:px-8 lg:px-12 xl:px-16 2xl:px-20 py-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm w-full">
         <div>
           <div className="flex items-center gap-2">
-            <img src="/logo-scriptlyfy.png" alt="Scriptlyfy" className="h-8 w-8 object-contain bg-transparent" />
+            <img
+              src="/logo-scriptlyfy.png"
+              alt="Scriptlyfy"
+              className="h-8 w-8 object-contain bg-transparent"
+            />
             <span className="text-lg font-semibold tracking-tight text-slate-900">
               Scriptlyfy
             </span>
@@ -105,7 +113,10 @@ export function Footer() {
             <li>
               <a
                 href="/features"
-                onClick={(e) => { e.preventDefault(); scrollToSection('features'); }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection("features");
+                }}
                 className="hover:text-slate-900"
               >
                 Features
@@ -114,7 +125,10 @@ export function Footer() {
             <li>
               <a
                 href="/demo"
-                onClick={(e) => { e.preventDefault(); scrollToSection('demo'); }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection("demo");
+                }}
                 className="hover:text-slate-900"
               >
                 Demo
@@ -123,7 +137,10 @@ export function Footer() {
             <li>
               <a
                 href="/pricing"
-                onClick={(e) => { e.preventDefault(); scrollToSection('pricing'); }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection("pricing");
+                }}
                 className="hover:text-slate-900"
               >
                 Pricing
@@ -157,7 +174,10 @@ export function Footer() {
             <li>
               <a
                 href="/signup"
-                onClick={(e) => { e.preventDefault(); scrollToSection('signup'); }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToSection("signup");
+                }}
                 className="hover:text-slate-900"
               >
                 Join Early Access
@@ -180,7 +200,7 @@ export function Footer() {
         </div>
       </div>
       <div className="border-t border-slate-200 py-4 text-center text-xs text-slate-500">
-  © {new Date().getFullYear()} Scriptlyfy. All rights reserved.
+        © {new Date().getFullYear()} Scriptlyfy. All rights reserved.
       </div>
     </footer>
   );
@@ -189,23 +209,30 @@ export function Footer() {
 export default function MainLayout({ children }: PropsWithChildren) {
   useEffect(() => {
     const onPop = () => {
-      const path = window.location.pathname.replace(/^\//, '');
-      const valid = new Set(['features','demo','pricing','faq','signup']);
+      const path = window.location.pathname.replace(/^\//, "");
+      const valid = new Set(["features", "demo", "pricing", "faq", "signup"]);
       if (valid.has(path)) {
         scrollToSection(path, false);
       }
     };
-    window.addEventListener('popstate', onPop);
-    return () => window.removeEventListener('popstate', onPop);
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
   }, []);
 
   return (
-    <div className={cn("min-h-dvh bg-white text-slate-900")}> 
+    <div className={cn("min-h-dvh bg-white text-slate-900")}>
       {/* Skip link for keyboard users */}
-      <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md focus:shadow">Skip to content</a>
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md focus:shadow"
+      >
+        Skip to content
+      </a>
       <Header />
       <main id="main">{children}</main>
-      <div data-observe="reveal"><Footer /></div>
+      <div data-observe="reveal">
+        <Footer />
+      </div>
     </div>
   );
 }

--- a/client/components/layout/MainLayout.tsx
+++ b/client/components/layout/MainLayout.tsx
@@ -205,7 +205,7 @@ export default function MainLayout({ children }: PropsWithChildren) {
       <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:bg-white focus:text-slate-900 focus:px-3 focus:py-2 focus:rounded-md focus:shadow">Skip to content</a>
       <Header />
       <main id="main">{children}</main>
-      <Footer />
+      <div data-observe="reveal"><Footer /></div>
     </div>
   );
 }

--- a/client/hooks/useReveal.ts
+++ b/client/hooks/useReveal.ts
@@ -22,10 +22,11 @@ export function useReveal(options?: { rootMargin?: string; threshold?: number })
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach(entry => {
+          const target = entry.target as HTMLElement;
           if (entry.isIntersecting) {
-            const target = entry.target as HTMLElement;
             target.setAttribute('data-in', 'true');
-            observer.unobserve(target); // one-shot
+          } else {
+            target.removeAttribute('data-in');
           }
         });
       },

--- a/client/hooks/useReveal.ts
+++ b/client/hooks/useReveal.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
 /**
  * useReveal
@@ -6,37 +6,44 @@ import { useEffect } from 'react';
  * data-in="true" on elements marked with data-observe="reveal" once they
  * enter the viewport. Respects prefers-reduced-motion.
  */
-export function useReveal(options?: { rootMargin?: string; threshold?: number }) {
+export function useReveal(options?: {
+  rootMargin?: string;
+  threshold?: number;
+}) {
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    const elements = Array.from(document.querySelectorAll<HTMLElement>('[data-observe="reveal"]'));
+    if (typeof window === "undefined") return;
+    const reduce = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    const elements = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-observe="reveal"]'),
+    );
     if (!elements.length) return;
 
     if (reduce) {
       // Instantly show without animation
-      elements.forEach(el => el.setAttribute('data-in', 'true'));
+      elements.forEach((el) => el.setAttribute("data-in", "true"));
       return;
     }
 
     const observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach(entry => {
+        entries.forEach((entry) => {
           if (entry.isIntersecting) {
             const target = entry.target as HTMLElement;
-            target.setAttribute('data-in', 'true');
+            target.setAttribute("data-in", "true");
             observer.unobserve(target);
           }
         });
       },
       {
         root: null,
-        rootMargin: options?.rootMargin || '0px 0px -10% 0px',
+        rootMargin: options?.rootMargin || "0px 0px -10% 0px",
         threshold: options?.threshold ?? 0.2,
-      }
+      },
     );
 
-    elements.forEach(el => observer.observe(el));
+    elements.forEach((el) => observer.observe(el));
 
     return () => observer.disconnect();
   }, [options?.rootMargin, options?.threshold]);

--- a/client/hooks/useReveal.ts
+++ b/client/hooks/useReveal.ts
@@ -22,11 +22,10 @@ export function useReveal(options?: { rootMargin?: string; threshold?: number })
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach(entry => {
-          const target = entry.target as HTMLElement;
           if (entry.isIntersecting) {
+            const target = entry.target as HTMLElement;
             target.setAttribute('data-in', 'true');
-          } else {
-            target.removeAttribute('data-in');
+            observer.unobserve(target);
           }
         });
       },

--- a/client/pages/BulkTranscribeInstagramPosts.tsx
+++ b/client/pages/BulkTranscribeInstagramPosts.tsx
@@ -1,25 +1,71 @@
-import React from 'react';
-import LeadForm from '@/components/landing/LeadForm';
-import SEO from '@/components/SEO';
-import { LastUpdated } from '@/lib/contentMeta.tsx';
+import React from "react";
+import LeadForm from "@/components/landing/LeadForm";
+import SEO from "@/components/SEO";
+import { LastUpdated } from "@/lib/contentMeta.tsx";
 
-const canonical = 'https://scriptlyfy.com/bulk-transcribe-instagram-posts';
+const canonical = "https://scriptlyfy.com/bulk-transcribe-instagram-posts";
 
 const faqs = [
-  { q: 'Do you extract captions and alt text?', a: 'Yes—captions are normalized and alt text is incorporated where accessible for semantic analysis.' },
-  { q: 'Is this only for video?', a: 'No. Standard feed posts (including carousels) with textual + contextual signals are processed for topic mapping.' },
-  { q: 'Can I analyze hook copy across formats?', a: 'Yes—post captions and Reel openings appear side-by-side for stylistic comparison.' },
-  { q: 'What export formats exist?', a: 'CSV and JSON with transcript/caption, hook lines, topics, and engagement signals (when available).' }
+  {
+    q: "Do you extract captions and alt text?",
+    a: "Yes—captions are normalized and alt text is incorporated where accessible for semantic analysis.",
+  },
+  {
+    q: "Is this only for video?",
+    a: "No. Standard feed posts (including carousels) with textual + contextual signals are processed for topic mapping.",
+  },
+  {
+    q: "Can I analyze hook copy across formats?",
+    a: "Yes—post captions and Reel openings appear side-by-side for stylistic comparison.",
+  },
+  {
+    q: "What export formats exist?",
+    a: "CSV and JSON with transcript/caption, hook lines, topics, and engagement signals (when available).",
+  },
 ];
 
 const jsonLd = [
-  { '@context': 'https://schema.org', '@type': 'BreadcrumbList', itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://scriptlyfy.com/' },
-    { '@type': 'ListItem', position: 2, name: 'Bulk Social Video Transcription', item: 'https://scriptlyfy.com/bulk-social-video-transcription' },
-    { '@type': 'ListItem', position: 3, name: 'Bulk Transcribe Instagram Posts', item: canonical }
-  ]},
-  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Bulk Transcribe Instagram Posts | Scriptlyfy', url: canonical, description: 'Bulk extract Instagram post captions & contextual signals. Build a topic & hook dataset from any public profile.' },
-  { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map(f => ({ '@type': 'Question', name: f.q, acceptedAnswer: { '@type': 'Answer', text: f.a } })) }
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://scriptlyfy.com/",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Bulk Social Video Transcription",
+        item: "https://scriptlyfy.com/bulk-social-video-transcription",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Bulk Transcribe Instagram Posts",
+        item: canonical,
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Bulk Transcribe Instagram Posts | Scriptlyfy",
+    url: canonical,
+    description:
+      "Bulk extract Instagram post captions & contextual signals. Build a topic & hook dataset from any public profile.",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  },
 ];
 
 export default function BulkTranscribeInstagramPostsPage() {
@@ -36,18 +82,40 @@ export default function BulkTranscribeInstagramPostsPage() {
         twitterDescription="Mine captions for hooks, topics & angles across competitors."
       />
       <header className="max-w-3xl mx-auto mb-10">
-        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 mb-4">Bulk Transcribe Instagram Posts</h1>
-  <p className="text-lg text-slate-700 leading-relaxed">Mine large sets of Instagram captions & contextual post data to identify narrative angles, hook phrasing, and topical positioning across a niche.</p>
-  <p className="mt-3 text-sm text-slate-500">← Back to the <a href="/bulk-social-video-transcription" className="underline">multi-platform transcription hub</a></p>
-        <div className="mt-2"><LastUpdated slug="bulk-transcribe-instagram-posts" /></div>
+        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 mb-4">
+          Bulk Transcribe Instagram Posts
+        </h1>
+        <p className="text-lg text-slate-700 leading-relaxed">
+          Mine large sets of Instagram captions & contextual post data to
+          identify narrative angles, hook phrasing, and topical positioning
+          across a niche.
+        </p>
+        <p className="mt-3 text-sm text-slate-500">
+          ← Back to the{" "}
+          <a href="/bulk-social-video-transcription" className="underline">
+            multi-platform transcription hub
+          </a>
+        </p>
+        <div className="mt-2">
+          <LastUpdated slug="bulk-transcribe-instagram-posts" />
+        </div>
       </header>
       <section className="max-w-4xl mx-auto mb-14 space-y-10">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">Why caption intelligence matters</h2>
-          <p className="text-slate-700 leading-relaxed">Captions drive depth, saves, and share-worthy framing. Manual aggregation across competitors is error-prone. Scriptlyfy automates extraction, normalization, and topic surfacing so you can systematize content ideation.</p>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            Why caption intelligence matters
+          </h2>
+          <p className="text-slate-700 leading-relaxed">
+            Captions drive depth, saves, and share-worthy framing. Manual
+            aggregation across competitors is error-prone. Scriptlyfy automates
+            extraction, normalization, and topic surfacing so you can
+            systematize content ideation.
+          </p>
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">What you get</h2>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            What you get
+          </h2>
           <ul className="list-disc ml-6 space-y-2 text-slate-700">
             <li>Batch caption ingestion & normalization</li>
             <li>Hook & opening phrase extraction</li>
@@ -58,7 +126,9 @@ export default function BulkTranscribeInstagramPostsPage() {
           </ul>
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">Workflow</h2>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            Workflow
+          </h2>
           <ol className="list-decimal ml-6 space-y-2 text-slate-700">
             <li>Enter a public Instagram profile</li>
             <li>Post captions + related metadata ingested</li>
@@ -70,7 +140,7 @@ export default function BulkTranscribeInstagramPostsPage() {
         <div>
           <h2 className="text-xl font-semibold text-slate-900 mb-3">FAQ</h2>
           <div className="space-y-6">
-            {faqs.map(f => (
+            {faqs.map((f) => (
               <div key={f.q}>
                 <h3 className="font-medium text-slate-800">{f.q}</h3>
                 <p className="text-slate-600 text-sm leading-relaxed">{f.a}</p>
@@ -81,8 +151,12 @@ export default function BulkTranscribeInstagramPostsPage() {
       </section>
       <section className="max-w-3xl mx-auto mb-16">
         <div className="rounded-2xl border border-slate-200 p-8 bg-white shadow-sm">
-          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Get early access</h2>
-          <p className="text-slate-600 mb-6">Join the waitlist to unlock bulk Instagram caption intelligence.</p>
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">
+            Get early access
+          </h2>
+          <p className="text-slate-600 mb-6">
+            Join the waitlist to unlock bulk Instagram caption intelligence.
+          </p>
           <LeadForm />
         </div>
       </section>

--- a/client/pages/BulkTranscribeYouTubeVideos.tsx
+++ b/client/pages/BulkTranscribeYouTubeVideos.tsx
@@ -1,25 +1,71 @@
-import React from 'react';
-import LeadForm from '@/components/landing/LeadForm';
-import SEO from '@/components/SEO';
-import { LastUpdated } from '@/lib/contentMeta.tsx';
+import React from "react";
+import LeadForm from "@/components/landing/LeadForm";
+import SEO from "@/components/SEO";
+import { LastUpdated } from "@/lib/contentMeta.tsx";
 
-const canonical = 'https://scriptlyfy.com/bulk-transcribe-youtube-videos';
+const canonical = "https://scriptlyfy.com/bulk-transcribe-youtube-videos";
 
 const faqs = [
-  { q: 'Do you support long-form YouTube videos in bulk?', a: 'Yes. Provide a channel or playlist and Scriptlyfy queues recent videos for transcription & structural extraction.' },
-  { q: 'How is this different from standard caption downloads?', a: 'We unify audio-derived transcripts, refine noise, segment narrative blocks, and surface hook & retention mechanics not obvious in raw captions.' },
-  { q: 'Can I filter by duration or topic?', a: 'Filtering + semantic tagging features are planned—early access focuses on batch processing & structural enrichment first.' },
-  { q: 'Can I compare long-form and short-form?', a: 'Yes. Contrast long-form narrative arcs with Shorts / Reels hook density to refine cross-format strategy.' }
+  {
+    q: "Do you support long-form YouTube videos in bulk?",
+    a: "Yes. Provide a channel or playlist and Scriptlyfy queues recent videos for transcription & structural extraction.",
+  },
+  {
+    q: "How is this different from standard caption downloads?",
+    a: "We unify audio-derived transcripts, refine noise, segment narrative blocks, and surface hook & retention mechanics not obvious in raw captions.",
+  },
+  {
+    q: "Can I filter by duration or topic?",
+    a: "Filtering + semantic tagging features are planned—early access focuses on batch processing & structural enrichment first.",
+  },
+  {
+    q: "Can I compare long-form and short-form?",
+    a: "Yes. Contrast long-form narrative arcs with Shorts / Reels hook density to refine cross-format strategy.",
+  },
 ];
 
 const jsonLd = [
-  { '@context': 'https://schema.org', '@type': 'BreadcrumbList', itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://scriptlyfy.com/' },
-    { '@type': 'ListItem', position: 2, name: 'Bulk Social Video Transcription', item: 'https://scriptlyfy.com/bulk-social-video-transcription' },
-    { '@type': 'ListItem', position: 3, name: 'Bulk Transcribe YouTube Videos', item: canonical }
-  ]},
-  { '@context': 'https://schema.org', '@type': 'WebPage', name: 'Bulk Transcribe YouTube Videos | Scriptlyfy', url: canonical, description: 'Bulk transcribe YouTube videos at scale. Extract structured scripts, hook sections, and reusable narrative segments.' },
-  { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map(f => ({ '@type': 'Question', name: f.q, acceptedAnswer: { '@type': 'Answer', text: f.a } })) }
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: "https://scriptlyfy.com/",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Bulk Social Video Transcription",
+        item: "https://scriptlyfy.com/bulk-social-video-transcription",
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Bulk Transcribe YouTube Videos",
+        item: canonical,
+      },
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Bulk Transcribe YouTube Videos | Scriptlyfy",
+    url: canonical,
+    description:
+      "Bulk transcribe YouTube videos at scale. Extract structured scripts, hook sections, and reusable narrative segments.",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  },
 ];
 
 export default function BulkTranscribeYouTubeVideosPage() {
@@ -36,18 +82,39 @@ export default function BulkTranscribeYouTubeVideosPage() {
         twitterDescription="Extract segments, hooks & reusable script blocks from channel archives."
       />
       <header className="max-w-3xl mx-auto mb-10">
-        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 mb-4">Bulk Transcribe YouTube Videos</h1>
-  <p className="text-lg text-slate-700 leading-relaxed">Convert long-form video libraries into structured, searchable script datasets. Identify hook positioning, narrative transitions, and retention scaffolds.</p>
-  <p className="mt-3 text-sm text-slate-500">← Back to the <a href="/bulk-social-video-transcription" className="underline">multi-platform transcription hub</a></p>
-        <div className="mt-2"><LastUpdated slug="bulk-transcribe-youtube-videos" /></div>
+        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-slate-900 mb-4">
+          Bulk Transcribe YouTube Videos
+        </h1>
+        <p className="text-lg text-slate-700 leading-relaxed">
+          Convert long-form video libraries into structured, searchable script
+          datasets. Identify hook positioning, narrative transitions, and
+          retention scaffolds.
+        </p>
+        <p className="mt-3 text-sm text-slate-500">
+          ← Back to the{" "}
+          <a href="/bulk-social-video-transcription" className="underline">
+            multi-platform transcription hub
+          </a>
+        </p>
+        <div className="mt-2">
+          <LastUpdated slug="bulk-transcribe-youtube-videos" />
+        </div>
       </header>
       <section className="max-w-4xl mx-auto mb-14 space-y-10">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">Why bulk long-form transcription?</h2>
-          <p className="text-slate-700 leading-relaxed">Researching dozens of videos manually wastes strategic cycles. Scriptlyfy automates ingestion, segment detection, and extraction so you can repurpose, summarize, and systematize topics faster.</p>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            Why bulk long-form transcription?
+          </h2>
+          <p className="text-slate-700 leading-relaxed">
+            Researching dozens of videos manually wastes strategic cycles.
+            Scriptlyfy automates ingestion, segment detection, and extraction so
+            you can repurpose, summarize, and systematize topics faster.
+          </p>
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">What you get</h2>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            What you get
+          </h2>
           <ul className="list-disc ml-6 space-y-2 text-slate-700">
             <li>Batch transcription of recent channel or playlist videos</li>
             <li>Narrative segment & chapter inference</li>
@@ -58,7 +125,9 @@ export default function BulkTranscribeYouTubeVideosPage() {
           </ul>
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-slate-900 mb-3">Workflow</h2>
+          <h2 className="text-xl font-semibold text-slate-900 mb-3">
+            Workflow
+          </h2>
           <ol className="list-decimal ml-6 space-y-2 text-slate-700">
             <li>Provide a channel or playlist</li>
             <li>Videos queued & processed concurrently</li>
@@ -70,7 +139,7 @@ export default function BulkTranscribeYouTubeVideosPage() {
         <div>
           <h2 className="text-xl font-semibold text-slate-900 mb-3">FAQ</h2>
           <div className="space-y-6">
-            {faqs.map(f => (
+            {faqs.map((f) => (
               <div key={f.q}>
                 <h3 className="font-medium text-slate-800">{f.q}</h3>
                 <p className="text-slate-600 text-sm leading-relaxed">{f.a}</p>
@@ -81,8 +150,13 @@ export default function BulkTranscribeYouTubeVideosPage() {
       </section>
       <section className="max-w-3xl mx-auto mb-16">
         <div className="rounded-2xl border border-slate-200 p-8 bg-white shadow-sm">
-          <h2 className="text-2xl font-semibold text-slate-900 mb-4">Get early access</h2>
-          <p className="text-slate-600 mb-6">Join the waitlist for multi-source YouTube transcription & structural insight.</p>
+          <h2 className="text-2xl font-semibold text-slate-900 mb-4">
+            Get early access
+          </h2>
+          <p className="text-slate-600 mb-6">
+            Join the waitlist for multi-source YouTube transcription &
+            structural insight.
+          </p>
           <LeadForm />
         </div>
       </section>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -24,22 +24,22 @@ export default function Index() {
       />
     <div>
       <Hero />
-  <TrustBar />
-  <SocialProof />
-      <Demo />
-      <Features />
+  <div data-observe="reveal"><TrustBar /></div>
+  <div data-observe="reveal"><SocialProof /></div>
+      <div data-observe="reveal"><Demo /></div>
+      <div data-observe="reveal"><Features /></div>
   {/* Testimonials for narrative credibility */}
   <div className="container mx-auto px-4 mt-16" data-observe="reveal"><Testimonials /></div>
       {/* Internal SEO link to new landing page */}
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8" data-observe="reveal">
         <div className="rounded-lg border border-slate-200 p-4 bg-white/60 text-sm text-slate-600">
           Looking to <a href="/bulk-transcribe-instagram-reels" className="text-[hsl(var(--brand))] underline">bulk transcribe Instagram Reels</a>? Also try our pages for <a href="/bulk-transcribe-tiktok-videos" className="underline">TikTok</a>, <a href="/bulk-transcribe-youtube-shorts" className="underline">YouTube Shorts</a>, <a href="/bulk-transcribe-youtube-videos" className="underline">YouTube videos</a>, and <a href="/bulk-transcribe-instagram-posts" className="underline">Instagram posts</a>.
         </div>
       </div>
-      <Pricing />
-      <Urgency />
-      <FAQ />
-      <LeadForm />
+      <div data-observe="reveal"><Pricing /></div>
+      <div data-observe="reveal"><Urgency /></div>
+      <div data-observe="reveal"><FAQ /></div>
+      <div data-observe="reveal"><LeadForm /></div>
     </div>
     </>
   );

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -22,25 +22,66 @@ export default function Index() {
         twitterTitle="Scriptlyfy: Bulk Short-Form Video Transcription"
         twitterDescription="Transcribe and analyze short-form video hooks at scale. Find patterns. Ship winning scripts faster."
       />
-    <div>
-      <Hero />
-  <div data-observe="reveal"><TrustBar /></div>
-  <div data-observe="reveal"><SocialProof /></div>
-      <div data-observe="reveal"><Demo /></div>
-      <div data-observe="reveal"><Features /></div>
-  {/* Testimonials for narrative credibility */}
-  <div className="container mx-auto px-4 mt-16" data-observe="reveal"><Testimonials /></div>
-      {/* Internal SEO link to new landing page */}
-      <div className="container mx-auto px-4 py-8" data-observe="reveal">
-        <div className="rounded-lg border border-slate-200 p-4 bg-white/60 text-sm text-slate-600">
-          Looking to <a href="/bulk-transcribe-instagram-reels" className="text-[hsl(var(--brand))] underline">bulk transcribe Instagram Reels</a>? Also try our pages for <a href="/bulk-transcribe-tiktok-videos" className="underline">TikTok</a>, <a href="/bulk-transcribe-youtube-shorts" className="underline">YouTube Shorts</a>, <a href="/bulk-transcribe-youtube-videos" className="underline">YouTube videos</a>, and <a href="/bulk-transcribe-instagram-posts" className="underline">Instagram posts</a>.
+      <div>
+        <Hero />
+        <div data-observe="reveal">
+          <TrustBar />
+        </div>
+        <div data-observe="reveal">
+          <SocialProof />
+        </div>
+        <div data-observe="reveal">
+          <Demo />
+        </div>
+        <div data-observe="reveal">
+          <Features />
+        </div>
+        {/* Testimonials for narrative credibility */}
+        <div className="container mx-auto px-4 mt-16" data-observe="reveal">
+          <Testimonials />
+        </div>
+        {/* Internal SEO link to new landing page */}
+        <div className="container mx-auto px-4 py-8" data-observe="reveal">
+          <div className="rounded-lg border border-slate-200 p-4 bg-white/60 text-sm text-slate-600">
+            Looking to{" "}
+            <a
+              href="/bulk-transcribe-instagram-reels"
+              className="text-[hsl(var(--brand))] underline"
+            >
+              bulk transcribe Instagram Reels
+            </a>
+            ? Also try our pages for{" "}
+            <a href="/bulk-transcribe-tiktok-videos" className="underline">
+              TikTok
+            </a>
+            ,{" "}
+            <a href="/bulk-transcribe-youtube-shorts" className="underline">
+              YouTube Shorts
+            </a>
+            ,{" "}
+            <a href="/bulk-transcribe-youtube-videos" className="underline">
+              YouTube videos
+            </a>
+            , and{" "}
+            <a href="/bulk-transcribe-instagram-posts" className="underline">
+              Instagram posts
+            </a>
+            .
+          </div>
+        </div>
+        <div data-observe="reveal">
+          <Pricing />
+        </div>
+        <div data-observe="reveal">
+          <Urgency />
+        </div>
+        <div data-observe="reveal">
+          <FAQ />
+        </div>
+        <div data-observe="reveal">
+          <LeadForm />
         </div>
       </div>
-      <div data-observe="reveal"><Pricing /></div>
-      <div data-observe="reveal"><Urgency /></div>
-      <div data-observe="reveal"><FAQ /></div>
-      <div data-observe="reveal"><LeadForm /></div>
-    </div>
     </>
   );
 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,7 +1,6 @@
 import Hero from "@/components/landing/Hero";
 import TrustBar from "@/components/landing/TrustBar";
 import SocialProof from "@/components/landing/SocialProof";
-import { LogoStrip } from "@/components/landing/social/LogoStrip";
 import Features from "@/components/landing/Features";
 import Demo from "@/components/landing/Demo";
 import Pricing from "@/components/landing/Pricing";
@@ -9,7 +8,6 @@ import FAQ from "@/components/landing/FAQ";
 import Urgency from "@/components/landing/Urgency";
 import LeadForm from "@/components/landing/LeadForm";
 import SEO from "@/components/SEO";
-import { LastUpdated } from "@/lib/contentMeta.tsx";
 import { Testimonials } from "@/components/landing/social/Testimonials";
 
 export default function Index() {
@@ -26,10 +24,7 @@ export default function Index() {
       />
     <div>
       <Hero />
-      <div className="container mx-auto px-4 mt-4"><LastUpdated slug="" /></div>
   <TrustBar />
-  {/* New lightweight logo social proof strip (early user / ecosystem cues) */}
-  <div className="mt-8" data-observe="reveal"><LogoStrip compact /></div>
   <SocialProof />
       <Demo />
       <Features />


### PR DESCRIPTION
## Purpose

The user wanted to implement smooth scroll-in animations for landing page sections (demo, features, pricing, testimonials, FAQ, footer) to create a premium user experience. They specifically requested one-time animations that trigger when users scroll down, similar to high-end applications, rather than repeated animations.

## Code changes

- **Enhanced useReveal hook**: Improved the intersection observer implementation with better TypeScript types and formatting for detecting when elements enter the viewport
- **Added reveal animations**: Wrapped all major landing page sections (TrustBar, SocialProof, Demo, Features, Testimonials, Pricing, Urgency, FAQ, LeadForm) and Footer with `data-observe="reveal"` attributes
- **Code formatting improvements**: Standardized quote usage from single to double quotes throughout MainLayout.tsx and improved code formatting consistency
- **Accessibility support**: Maintained respect for `prefers-reduced-motion` setting to instantly show content without animations for users who prefer reduced motion

The animations are one-time only - once a section is revealed, it stays visible and won't re-animate on subsequent scrolls.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/155a92418eeb4d8ca20c01a14a5130aa/zen-forge)

👀 [Preview Link](https://155a92418eeb4d8ca20c01a14a5130aa-zen-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>155a92418eeb4d8ca20c01a14a5130aa</projectId>-->
<!--<branchName>zen-forge</branchName>-->